### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-master.yml
+++ b/.github/workflows/docker-master.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Build and publish to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kdrag0n/pyrobud:unstable
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Build and publish to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kdrag0n/pyrobud:latest
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore